### PR TITLE
Arrange unordered frames in a grid-like pattern

### DIFF
--- a/funkin-utils/general/spritesheet-packer.html
+++ b/funkin-utils/general/spritesheet-packer.html
@@ -276,14 +276,30 @@
 			}
 		}
 
+		let areaShrunk = false;
+
 		for (let w = low; w <= high; w++) {
 			const h = packHeight(w);
 			const area = w * h;
 			if (area < bestArea) {
+				areaShrunk = true;
 				bestArea = area;
 				bestW = w;
 				bestH = h;
 			}
+		}
+
+		// special case: if the shrinking algorithm hasnt run at all, position the frames in a grid-like pattern
+		if (!areaShrunk)
+		{
+			let rows = Math.ceil(Math.sqrt(boxes.length));
+			let totalW = 0;
+			for (let i = totalW; i < rows; i++)
+			{
+				totalW += widths[i];
+			}
+
+			bestW = totalW;
 		}
 
 		const [finalH, rawPlacements] = makeLayout(bestW);


### PR DESCRIPTION
In a few cases, the algorithm finds it better to put frames under each other to be the most optimized. However, some devices struggle with reading these spritesheets, as the height of these generated spritesheets can range to several thousands of pixels in size.

This PR makes it so that the algorithm arranges the frames in a grid-like pattern whenever that's the case, with a preference to width. While it isn't the most optimized in terms of file size, it doesn't have the problem of some devices being unable to load the spritesheets.